### PR TITLE
Ensure that a created secret is available as a concrete type

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Safely load secrets from sops into secretsmanager using the CDK
 ```typescript
 import { SopsSecretsManager } from 'sops-secretsmanager-cdk';
 ...
-new SopsSecretsManager(this, 'StoreSecrets', {
+const ssm = new SopsSecretsManager(this, 'StoreSecrets', {
     path: './path/to/secretsfile.yaml',
     kmsKey: myKey,  // or use kms.Key.fromKeyArn, or omit and use the key in the sops file
     secretName: 'TestSecret',  // or secret: mySecret
@@ -21,6 +21,11 @@ new SopsSecretsManager(this, 'StoreSecrets', {
         // etc
     },
 });
+
+if(ssm.secret) {
+    // secret is a Secret you can tag, for example
+}
+
 ```
 
 ## Implementation

--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ export interface SopsSecretsManagerMappings {
 }
 
 export interface SopsSecretsManagerProps {
-    readonly secret?: secretsManager.ISecret;
+    readonly secret?: secretsManager.Secret | secretsManager.ISecret;
     readonly secretName?: string;
     readonly asset?: s3Assets.Asset;
     readonly path?: string;
@@ -70,7 +70,7 @@ class SopsSecretsManagerProvider extends cdk.Construct {
 }
 
 export class SopsSecretsManager extends cdk.Construct {
-    public readonly secret: secretsManager.ISecret;
+    public readonly secret: secretsManager.Secret | secretsManager.ISecret;
     public readonly asset: s3Assets.Asset;
 
     constructor(scope: cdk.Construct, id: string, props: SopsSecretsManagerProps) {
@@ -94,7 +94,7 @@ export class SopsSecretsManager extends cdk.Construct {
         });
     }
 
-    public getSecret(secret?: secretsManager.ISecret, secretName?: string): secretsManager.ISecret {
+    public getSecret(secret?: secretsManager.Secret | secretsManager.ISecret, secretName?: string): secretsManager.Secret | secretsManager.ISecret {
         if (secret && secretName) {
             throw new Error('Cannot set both secret and secretName');
         }


### PR DESCRIPTION
We just return whatever we were given, or what we've got. It is up to the user to know what they provided.

This works, I can tag secrets created by this resource.
