### PR TITLE
Handle whole file secret

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -93,6 +93,12 @@ export class SopsSecretsManager extends cdk.Construct {
         }
         this.asset = this.getAsset(props.asset, props.path);
 
+        if (props.wholeFile && props.mappings) {
+            throw new Error('Cannot set mappings and set wholeFile to true');
+        } else if (!props.wholeFile && !props.mappings) {
+            throw new Error('Must set mappings or set wholeFile to true');
+        }
+
         new cfn.CustomResource(this, 'Resource', {
             provider: SopsSecretsManagerProvider.getOrCreate(this),
             resourceType: 'Custom::SopsSecretsManager',

--- a/index.ts
+++ b/index.ts
@@ -27,7 +27,8 @@ export interface SopsSecretsManagerProps {
     readonly asset?: s3Assets.Asset;
     readonly path?: string;
     readonly kmsKey?: kms.IKey;
-    readonly mappings: SopsSecretsManagerMappings;
+    readonly mappings?: SopsSecretsManagerMappings;
+    readonly wholeFile?: boolean;
     readonly fileType?: SopsSecretsManagerFileType;
 }
 
@@ -101,7 +102,8 @@ export class SopsSecretsManager extends cdk.Construct {
                 S3Path: this.asset.s3ObjectKey,
                 SourceHash: this.asset.sourceHash,
                 KMSKeyArn: props.kmsKey?.keyArn,
-                Mappings: JSON.stringify(props.mappings),
+                Mappings: JSON.stringify(props.mappings || {}),
+                WholeFile: props.wholeFile || false,
                 FileType: props.fileType,
             },
         });


### PR DESCRIPTION
Fixes #16.

If `wholeFile` is true, then get the `data` key from the output, and set that as the secret.