### PR TITLE
Fix type marshalling for boolean

### DIFF
--- a/provider/index.ts
+++ b/provider/index.ts
@@ -75,7 +75,7 @@ const normaliseBoolean = (value: boolean | string): boolean => {
         throw new Error(`Unexpected string value when normalising boolean: ${value}`);
     }
     throw new Error(`Unexpected type ${typeof value}, ${value} when normalising boolean`);
-}
+};
 
 const determineFileType = (s3Path: string, fileType: string | undefined, wholeFile: boolean): string => {
     if (fileType) {

--- a/provider/index.ts
+++ b/provider/index.ts
@@ -28,7 +28,7 @@ interface ResourceProperties {
     S3Bucket: string;
     S3Path: string;
     Mappings: string; // json encoded Mappings;
-    WholeFile: boolean;
+    WholeFile: boolean | string;
     SecretArn: string;
     SourceHash: string;
     FileType: string | undefined;
@@ -60,6 +60,22 @@ interface Response {
 }
 
 type Event = CreateEvent | UpdateEvent | DeleteEvent;
+
+const normaliseBoolean = (value: boolean | string): boolean => {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (typeof value === 'string') {
+        if (value === 'true') {
+            return true;
+        }
+        if (value === 'false') {
+            return false;
+        }
+        throw new Error(`Unexpected string value when normalising boolean: ${value}`);
+    }
+    throw new Error(`Unexpected type ${typeof value}, ${value} when normalising boolean`);
+}
 
 const determineFileType = (s3Path: string, fileType: string | undefined, wholeFile: boolean): string => {
     if (fileType) {
@@ -179,7 +195,7 @@ const handleCreate = async (event: CreateEvent): Promise<Response> => {
     const s3BucketName = event.ResourceProperties.S3Bucket;
     const s3Path = event.ResourceProperties.S3Path;
     const mappings = JSON.parse(event.ResourceProperties.Mappings) as Mappings;
-    const wholeFile = event.ResourceProperties.WholeFile;
+    const wholeFile = normaliseBoolean(event.ResourceProperties.WholeFile);
     const secretArn = event.ResourceProperties.SecretArn;
     // const sourceHash = event.ResourceProperties.SourceHash;
     const fileType = event.ResourceProperties.FileType;

--- a/provider/tests/index.test.ts
+++ b/provider/tests/index.test.ts
@@ -207,7 +207,7 @@ describe('onCreate', () => {
                         encoding: 'json',
                     },
                 }),
-                WholeFile: 'false',  // because a boolean set in the CDK becomes a string once it reaches the provider
+                WholeFile: 'false', // because a boolean set in the CDK becomes a string once it reaches the provider
                 SecretArn: 'mysecretarn',
                 SourceHash: '123',
                 FileType: undefined,


### PR DESCRIPTION
I found that the `wholeFile` value becomes a string once it reaches the provider, which might be a bug somewhere in the provider framework, or maybe I'm not successfully specifying that it is a boolean. Not sure.

But this handles either boolean or a stringified-boolean.