### PR TITLE
Fix construct linting

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -147,7 +147,7 @@ test('can pass an asset rather than a path', () => {
         path: './test/test.yaml',
     });
 
-    const secretValues = new SopsSecretsManager(stack, 'SecretValues', {
+    new SopsSecretsManager(stack, 'SecretValues', {
         secretName: 'MySecret',
         asset: secretAsset,
         mappings: {


### PR DESCRIPTION
Automerge merged https://github.com/isotoma/sops-secretsmanager-cdk/pull/35 because CI wasn't marked as required. Believe now fixed and this should verify that.