### PR TITLE
More helpful lint command that doesn't hide errors in cannot fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "clean": "rm -rf build/",
         "compile": "npm run clean && npm run -- tsc --outDir build/ && (cd provider && npm install && npm run compile) && cp -R ./provider/build/ ./build/provider/ && cp package.json README.md ./build/",
         "version": "auto-changelog --template ./changelog_template.hbs -p && git add CHANGELOG.md",
-        "lint": "eslint 'index.ts' 'test/**/*.ts' jest.config.js --quiet --fix",
+        "lint": "eslint 'index.ts' 'test/**/*.ts' jest.config.js --fix",
         "lint-check": "eslint 'index.ts' 'test/**/*.ts' jest.config.js --max-warnings 0"
     },
     "dependencies": {

--- a/provider/package.json
+++ b/provider/package.json
@@ -13,7 +13,7 @@
         "compile": "npm run clean && npm run -- tsc --outDir build/ --declaration false && npm run get-sops && cp -R ./sops ./build/",
         "quick-compile": "npm run -- tsc --outDir build/ --declaration false && ([[ -f ./sops ]] || npm run get-sops) && cp ./sops ./build/",
         "test": "jest",
-        "lint": "eslint 'index.ts' 'tests/**/*.ts' jest.config.js --quiet --fix",
+        "lint": "eslint 'index.ts' 'tests/**/*.ts' jest.config.js --fix",
         "lint-check": "eslint 'index.ts' 'tests/**/*.ts' jest.config.js --max-warnings 0"
     },
     "dependencies": {


### PR DESCRIPTION
The `--quiet` option is not useful here. If eslint cannot fix a problem itself, it should say so.