### PR TITLE
Hack example to remove implicit node10 usage by the CDK

### DIFF
--- a/example/sops-example/lib/sops-example-stack.ts
+++ b/example/sops-example/lib/sops-example-stack.ts
@@ -1,5 +1,7 @@
 import * as cdk from '@aws-cdk/core';
 import * as secretsmanager from '@aws-cdk/aws-secretsmanager';
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as customResource from '@aws-cdk/custom-resources';
 
 import { SopsSecretsManager } from './sops-secretsmanager-cdk-dev';
 
@@ -21,6 +23,16 @@ export class SopsExampleStack extends cdk.Stack {
                 },
             },
         });
+
+        // This section hacks the CDK's utility lambda to use Node 12,
+        // which uses Node 10 in cdk <1.94.0. This is no longer
+        // deployable as of July 30, 2021.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const providerWrapper = cdk.Stack.of(this).node.findChild('com.isotoma.cdk.custom-resources.sops-secrets-manager') as any;
+        const provider = providerWrapper.provider as customResource.Provider;
+        const lambdaFn = (provider.node.findChild('framework-onEvent') as unknown) as lambda.Function;
+        const cfnLambdaFn = lambdaFn.node.defaultChild as lambda.CfnFunction;
+        cfnLambdaFn.addPropertyOverride('Runtime', lambda.Runtime.NODEJS_12_X.toString());
 
         new cdk.CfnOutput(this, 'TestSecretArn', {
             value: secret.secretArn,


### PR DESCRIPTION
Argue with the CDK to get at the on-event function deployed by the CDK. In CDK<1.94.0, this uses Node 10, which is no longer deployable. This shows how to persuade it to use node12 instead, which will probably work without issue.