### PR TITLE
Remove hackToForceNode12

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ if(ssm.secret) {
     - tells sops how to decode the file
     - will default getting the extension from the filename
     - unless `wholeFile` is true, then defaults to `'json'`
-- `hackToForceNode12` - optional, `boolean`
-    - if set to `true`, hacks the implicit Lambda used by the CDK to invoke the Sops lambda to use Node12
-    - this is required for deploying any new Lambdas using CDK<1.94.0 since 30th July 2021
 
 ### Mappings
 
@@ -85,8 +82,6 @@ CDK v2:
 ```typescript
 import { SopsSecretsManager } from 'sops-secretsmanager-cdk/cdkv2';
 ```
-
-Note: `hackToForceNode12` has no effect with CDK v2.
 
 ## Implementation
 

--- a/common.ts
+++ b/common.ts
@@ -22,7 +22,6 @@ export interface SopsSecretsManagerBaseProps {
     readonly mappings?: SopsSecretsManagerMappings;
     readonly wholeFile?: boolean;
     readonly fileType?: SopsSecretsManagerFileType;
-    readonly hackToForceNode12?: boolean;
 }
 
 export const providerId = 'com.isotoma.cdk.custom-resources.sops-secrets-manager';

--- a/test/cdkv1.test.ts
+++ b/test/cdkv1.test.ts
@@ -248,24 +248,3 @@ test('uses a secret, creates a custom resource', () => {
         }),
     );
 });
-
-test('lambda runtimes, force node12', () => {
-    const stack = new Stack();
-
-    new SopsSecretsManager(stack, 'SecretValues', {
-        secretName: 'MySecret',
-        path: './test/test.yaml',
-        mappings: {
-            mykey: {
-                path: ['a', 'b'],
-            },
-        },
-        hackToForceNode12: true,
-    });
-
-    cdkExpect(stack).notTo(
-        haveResource('AWS::Lambda::Function', {
-            Runtime: 'nodejs10.x',
-        }),
-    );
-});


### PR DESCRIPTION
This is a breaking change, so will warrant a major version bump.

This codebase shouldn't handle hacks like this. Could use https://github.com/plumdog/cdk-10to12/ or similar instead.