### PR TITLE
Change index exports to cdkv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,16 @@ It takes an object, where:
 
 ## CDK v1 and v2
 
-CDK v1:
+CDK v2:
 ```typescript
 import { SopsSecretsManager } from 'sops-secretsmanager-cdk';
 // or
-import { SopsSecretsManager } from 'sops-secretsmanager-cdk/cdkv1';
+import { SopsSecretsManager } from 'sops-secretsmanager-cdk/cdkv2';
 ```
 
-CDK v2:
+CDK v1:
 ```typescript
-import { SopsSecretsManager } from 'sops-secretsmanager-cdk/cdkv2';
+import { SopsSecretsManager } from 'sops-secretsmanager-cdk/cdkv1';
 ```
 
 ## Implementation

--- a/example/sops-example/lib/sops-example-stack.ts
+++ b/example/sops-example/lib/sops-example-stack.ts
@@ -3,7 +3,7 @@ import * as secretsmanager from '@aws-cdk/aws-secretsmanager';
 import * as lambda from '@aws-cdk/aws-lambda';
 import * as customResource from '@aws-cdk/custom-resources';
 
-import { SopsSecretsManager } from './sops-secretsmanager-cdk-dev';
+import { SopsSecretsManager } from './sops-secretsmanager-cdk-dev/cdkv1';
 
 export class SopsExampleStack extends cdk.Stack {
     constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,1 @@
-// For now, the exports from index.ts are CDK v1
-export * from './cdkv1';
+export * from './cdkv2';


### PR DESCRIPTION
CDK v1 is going EOL. Retaining the old code for now because it does still work.

Required changes:
- If you are using CDK v1, you _must_ change imports:
    - from: `import { SopsSecretsManager } from 'sops-secretsmanager-cdk`
    - to: `import { SopsSecretsManager } from 'sops-secretsmanager-cdk/cdkv1`

Recommended changes:
- If you are using CDK v2, you should change imports (not required yet, but will become mandatory in a future major release)
    - from: `import { SopsSecretsManager } from 'sops-secretsmanager-cdk/cdkv2`
    - to: `import { SopsSecretsManager } from 'sops-secretsmanager-cdk`