### PR TITLE
Add singleValueMapping option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ if(ssm.secret) {
 - `kmsKey` - optional
     - must be a `kms.IKey`
     - the sops file contains a reference to the KMS key, so probably not actually needed
-- `mappings` and `wholeFile` - must set `mappings` or set `wholeFile` to `true`
+- `mappings`, `wholeFile` and `singleValueMapping` - must set `mappings` or `singleValueMapping` or set `wholeFile` to `true`
     - if `mappings`, must be a `SopsSecretsManagerMappings`
         - which determines how the values from the sops file are mapped to keys in the secret (see below)
+    - if `singleValueMapping`, must be a `SopsSecretsManagerMapping`
+         - which determines how a single value from the sops file is mapped to the text value of the secret
     - if `wholeFile` is true
         - then rather than treating the sops data as structured and mapping keys over, the whole file will be decrypted and stored as the body of the secret
 - `fileType` - optional

--- a/cdkv1.ts
+++ b/cdkv1.ts
@@ -71,10 +71,19 @@ export class SopsSecretsManager extends cdk.Construct {
         }
         this.asset = this.getAsset(props.asset, props.path);
 
-        if (props.wholeFile && props.mappings) {
-            throw new Error('Cannot set mappings and set wholeFile to true');
-        } else if (!props.wholeFile && !props.mappings) {
-            throw new Error('Must set mappings or set wholeFile to true');
+        const mutuallyExclusiveProps: Record<string, boolean> = {
+            wholeFile: !!props.wholeFile,
+            mappings: !!props.mappings,
+            singleValueMapping: !!props.singleValueMapping,
+        }
+
+        const mutuallyExclusivePropsEnabled = Object.keys(mutuallyExclusiveProps).filter((key) => mutuallyExclusiveProps[key]);
+        if (mutuallyExclusivePropsEnabled.length > 1) {
+            throw new Error(`Cannot set more than one of ${mutuallyExclusivePropsEnabled.join(', ')}`);
+        }
+
+        if (mutuallyExclusivePropsEnabled.length === 0) {
+            throw new Error(`Must set one of ${Object.keys(mutuallyExclusiveProps).join(', ')}`);
         }
 
         new cfn.CustomResource(this, 'Resource', {
@@ -87,6 +96,7 @@ export class SopsSecretsManager extends cdk.Construct {
                 SourceHash: this.asset.sourceHash,
                 KMSKeyArn: props.kmsKey?.keyArn,
                 Mappings: JSON.stringify(props.mappings || {}),
+                SingleValueMapping: JSON.stringify(props.singleValueMapping || null),
                 WholeFile: props.wholeFile || false,
                 FileType: props.fileType,
             },

--- a/common.ts
+++ b/common.ts
@@ -21,6 +21,7 @@ export interface SopsSecretsManagerBaseProps {
     readonly kmsKey?: unknown;
     readonly mappings?: SopsSecretsManagerMappings;
     readonly wholeFile?: boolean;
+    readonly singleValueMapping?: SopsSecretsManagerMapping;
     readonly fileType?: SopsSecretsManagerFileType;
 }
 

--- a/provider/tests/index.test.ts
+++ b/provider/tests/index.test.ts
@@ -115,6 +115,7 @@ describe('onCreate', () => {
                             path: ['a'],
                         },
                     }),
+                    SingleValueMapping: JSON.stringify(null),
                     WholeFile: false,
                     SecretArn: 'mysecretarn',
                     SourceHash: '123',
@@ -175,6 +176,7 @@ describe('onCreate', () => {
                             path: ['a'],
                         },
                     }),
+                    SingleValueMapping: JSON.stringify(null),
                     WholeFile: false,
                     SecretArn: 'mysecretarn',
                     SourceHash: '123',
@@ -221,6 +223,7 @@ describe('onCreate', () => {
                             path: ['a'],
                         },
                     }),
+                    SingleValueMapping: JSON.stringify(null),
                     WholeFile: false,
                     SecretArn: 'mysecretarn',
                     SourceHash: '123',
@@ -262,6 +265,7 @@ describe('onCreate', () => {
                         encoding: 'json',
                     },
                 }),
+                SingleValueMapping: JSON.stringify(null),
                 WholeFile: false,
                 SecretArn: 'mysecretarn',
                 SourceHash: '123',
@@ -303,6 +307,7 @@ describe('onCreate', () => {
                         encoding: 'json',
                     },
                 }),
+                SingleValueMapping: JSON.stringify(null),
                 WholeFile: 'false', // because a boolean set in the CDK becomes a string once it reaches the provider
                 SecretArn: 'mysecretarn',
                 SourceHash: '123',
@@ -337,6 +342,7 @@ describe('onCreate', () => {
                 S3Bucket: 'mys3bucket',
                 S3Path: 'mys3path.txt',
                 Mappings: JSON.stringify({}),
+                SingleValueMapping: JSON.stringify(null),
                 WholeFile: true,
                 SecretArn: 'mysecretarn',
                 SourceHash: '123',
@@ -356,6 +362,38 @@ describe('onCreate', () => {
         expect(mockSecretsManagerPutSecretValue).toBeCalledWith({
             SecretId: 'mysecretarn',
             SecretString: 'mysecretdata',
+        });
+    });
+
+    test('singleValueMapping', async () => {
+        setMockSpawn({
+            stdoutData: JSON.stringify({
+                a: {
+                    b: 'c',
+                },
+            }),
+        });
+
+        await onEvent({
+            RequestType: 'Create',
+            ResourceProperties: {
+                KMSKeyArn: undefined,
+                S3Bucket: 'mys3bucket',
+                S3Path: 'mys3path.txt',
+                Mappings: JSON.stringify({}),
+                SingleValueMapping: JSON.stringify({
+                    path: ['a', 'b'],
+                }),
+                WholeFile: false,
+                SecretArn: 'mysecretarn',
+                SourceHash: '123',
+                FileType: undefined,
+            },
+        });
+
+        expect(mockSecretsManagerPutSecretValue).toBeCalledWith({
+            SecretId: 'mysecretarn',
+            SecretString: 'c',
         });
     });
 
@@ -383,6 +421,7 @@ describe('onCreate', () => {
                             path: ['a'],
                         },
                     }),
+                    SingleValueMapping: JSON.stringify(null),
                     WholeFile: false,
                     SecretArn: 'mysecretarn',
                     SourceHash: '123',
@@ -436,6 +475,7 @@ describe('onUpdate', () => {
                             path: ['a'],
                         },
                     }),
+                    SingleValueMapping: JSON.stringify(null),
                     WholeFile: false,
                     SecretArn: 'mysecretarn',
                     SourceHash: '123',
@@ -554,6 +594,7 @@ describe('invalid event attribute value shapes', () => {
                     path: ['a'],
                 },
             }),
+            SingleValueMapping: JSON.stringify(null),
             WholeFile: false,
             SecretArn: 'mysecretarn',
             SourceHash: '123',


### PR DESCRIPTION
To allow, eg:

```yaml
# secrets.yaml, a sops encrypted file with plaintext contents
a:
  b: 'c'
```

```typescript
new SopsSecretsManager(this, 'MyApiKey', {
    path: './secrets.yaml',
    secret: mySecret,
    singleValueMapping: {
        path: ['a', 'b'],
    },
});
```

would result in `mySecret` having contents `c`.