### PR TITLE
Reduce Lambda IAM scope

### DIFF
--- a/cdkv2.ts
+++ b/cdkv2.ts
@@ -84,6 +84,14 @@ export class SopsSecretsManager extends constructs.Construct {
         }
 
         const provider = SopsSecretsManagerProvider.getOrCreate(this);
+        const providerFn = provider.onEventHandler;
+
+        this.asset.grantRead(providerFn);
+
+        const secretForGrant: secretsManager.ISecret = props.secret ?? this.secret!;
+        secretForGrant.grantWrite(providerFn);
+
+        props.kmsKey?.grantDecrypt(providerFn);
 
         new cdk.CustomResource(this, 'Resource', {
             serviceToken: provider.serviceToken,

--- a/cdkv2.ts
+++ b/cdkv2.ts
@@ -28,20 +28,13 @@ class SopsSecretsManagerProvider extends constructs.Construct {
     constructor(scope: constructs.Construct, id: string) {
         super(scope, id);
 
-        const policyStatements: Array<iam.PolicyStatement> = [];
-        for (const statement of common.providerPolicyStatements) {
-            policyStatements.push(new iam.PolicyStatement(statement));
-        }
-
-        this.provider = new customResource.Provider(this, common.providerLogicalId, {
-            onEventHandler: new lambda.Function(this, common.providerFunctionLogicalId, {
-                code: lambda.Code.fromAsset(common.providerCodePath),
-                runtime: new lambda.Runtime('nodejs22.x', lambda.RuntimeFamily.NODEJS, { supportsInlineCode: true }),
-                handler: common.providerHandler,
-                timeout: cdk.Duration.minutes(common.providerTimoutMinutes),
-                initialPolicy: policyStatements,
-            }),
+        const onEventHandler = new lambda.Function(this, common.providerFunctionLogicalId, {
+            code: lambda.Code.fromAsset(common.providerCodePath),
+            runtime: lambda.Runtime.NODEJS_22_X,
+            handler: common.providerHandler,
+            timeout: cdk.Duration.minutes(common.providerTimoutMinutes),
         });
+        this.provider = new customResource.Provider(this, common.providerLogicalId, { onEventHandler });
     }
 }
 
@@ -91,7 +84,16 @@ export class SopsSecretsManager extends constructs.Construct {
         const secretForGrant: secretsManager.ISecret = props.secret ?? this.secret!;
         secretForGrant.grantWrite(providerFn);
 
-        props.kmsKey?.grantDecrypt(providerFn);
+        if (props.kmsKey) {
+            props.kmsKey.grantDecrypt(providerFn);
+        } else {
+            // The KMS key ARN is embedded in the SOPS file and only known at
+            // runtime, so a wildcard resource grant is needed as a fallback.
+            providerFn.addToRolePolicy(new iam.PolicyStatement({
+                resources: ['*'],
+                actions: ['kms:Decrypt'],
+            }));
+        }
 
         new cdk.CustomResource(this, 'Resource', {
             serviceToken: provider.serviceToken,

--- a/cdkv2.ts
+++ b/cdkv2.ts
@@ -30,7 +30,7 @@ class SopsSecretsManagerProvider extends constructs.Construct {
 
         const onEventHandler = new lambda.Function(this, common.providerFunctionLogicalId, {
             code: lambda.Code.fromAsset(common.providerCodePath),
-            runtime: lambda.Runtime.NODEJS_22_X,
+            runtime: new lambda.Runtime('nodejs22.x', lambda.RuntimeFamily.NODEJS, { supportsInlineCode: true }),
             handler: common.providerHandler,
             timeout: cdk.Duration.minutes(common.providerTimoutMinutes),
         });

--- a/common.ts
+++ b/common.ts
@@ -39,11 +39,5 @@ interface PolicyStatement {
 
 export const providerPolicyStatements: Array<PolicyStatement> = [{
     resources: ['*'],
-    actions: ['s3:GetObject*', 's3:GetBucket*', 's3:List*', 's3:DeleteObject*', 's3:PutObject*', 's3:Abort*'],
-}, {
-    resources: ['*'],
-    actions: ['kms:*'],
-}, {
-    resources: ['*'],
-    actions: ['secretsmanager:*'],
+    actions: ['kms:Decrypt'],
 }];

--- a/common.ts
+++ b/common.ts
@@ -37,4 +37,10 @@ interface PolicyStatement {
     actions: Array<string>;
 };
 
+/**
+ * @deprecated Retained for backwards compatibility only. The provider Lambda's
+ * permissions are now granted directly in SopsSecretsManager via scoped
+ * grant*() calls (asset read, secret write, KMS decrypt), so this is
+ * intentionally empty and is no longer a supported customization point.
+ */
 export const providerPolicyStatements: Array<PolicyStatement> = [];

--- a/common.ts
+++ b/common.ts
@@ -37,7 +37,4 @@ interface PolicyStatement {
     actions: Array<string>;
 };
 
-export const providerPolicyStatements: Array<PolicyStatement> = [{
-    resources: ['*'],
-    actions: ['kms:Decrypt'],
-}];
+export const providerPolicyStatements: Array<PolicyStatement> = [];

--- a/test/cdkv2.test.ts
+++ b/test/cdkv2.test.ts
@@ -238,7 +238,6 @@ test('grants scoped S3 read access to the asset for the Lambda', () => {
     expect(s3Statements.length).toBeGreaterThan(0);
     for (const stmt of s3Statements) {
         expect(stmt.Resource).not.toBe('*');
-        expect(Array.isArray(stmt.Resource)).toBe(true);
     }
 
     void secretValues;

--- a/test/cdkv2.test.ts
+++ b/test/cdkv2.test.ts
@@ -217,6 +217,12 @@ const allPolicyStatements = (template: Template): Array<Record<string, unknown>>
         (p: any) => p.Properties?.PolicyDocument?.Statement ?? [],
     );
 
+const hasWildcardAction = (statements: Array<Record<string, unknown>>, action: string): boolean =>
+    statements.some((s) =>
+        s.Action === action ||
+        (Array.isArray(s.Action) && (s.Action as string[]).includes(action)),
+    );
+
 test('grants scoped S3 read access to the asset for the Lambda', () => {
     const stack = new Stack();
 
@@ -271,8 +277,7 @@ test('grants scoped SecretsManager write access to the specific secret for the L
         },
     });
 
-    const wildcardSM = allPolicyStatements(template).filter((s) => s.Action === 'secretsmanager:*');
-    expect(wildcardSM).toHaveLength(0);
+    expect(hasWildcardAction(allPolicyStatements(template), 'secretsmanager:*')).toBe(false);
 });
 
 test('grants scoped SecretsManager write access when passing an existing secret', () => {
@@ -334,8 +339,37 @@ test('grants scoped KMS decrypt access when a kmsKey is provided', () => {
         },
     });
 
-    const wildcardKMS = allPolicyStatements(template).filter((s) => s.Action === 'kms:*');
-    expect(wildcardKMS).toHaveLength(0);
+    expect(hasWildcardAction(allPolicyStatements(template), 'kms:*')).toBe(false);
+
+    // When a specific key is provided the resource must also be scoped (no kms:Decrypt *)
+    const wildcardDecrypt = allPolicyStatements(template).filter((s) => {
+        const isDecrypt = s.Action === 'kms:Decrypt' || (Array.isArray(s.Action) && (s.Action as string[]).includes('kms:Decrypt'));
+        return isDecrypt && s.Resource === '*';
+    });
+    expect(wildcardDecrypt).toHaveLength(0);
+});
+
+test('falls back to kms:Decrypt * when no kmsKey is provided', () => {
+    const stack = new Stack();
+
+    new SopsSecretsManager(stack, 'SecretValues', {
+        secretName: 'MySecret',
+        path: './test/test.yaml',
+        mappings: {
+            mykey: {
+                path: ['a', 'b'],
+            },
+        },
+    });
+
+    const template = Template.fromStack(stack);
+    const stmts = allPolicyStatements(template);
+
+    const wildcardDecrypt = stmts.filter((s) => {
+        const isDecrypt = s.Action === 'kms:Decrypt' || (Array.isArray(s.Action) && (s.Action as string[]).includes('kms:Decrypt'));
+        return isDecrypt && s.Resource === '*';
+    });
+    expect(wildcardDecrypt.length).toBeGreaterThan(0);
 });
 
 // No node12 hack behaviour to test in cdk v2

--- a/test/cdkv2.test.ts
+++ b/test/cdkv2.test.ts
@@ -1,4 +1,4 @@
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { Stack } from 'aws-cdk-lib/core';
 import { SopsSecretsManager } from '../cdkv2';
 import * as secretsManager from 'aws-cdk-lib/aws-secretsmanager';
@@ -210,6 +210,132 @@ test('uses a secret, creates a custom resource', () => {
     template.hasResourceProperties('AWS::SecretsManager::Secret', {
         Name: 'MySecret',
     });
+});
+
+const allPolicyStatements = (template: Template): Array<Record<string, unknown>> =>
+    Object.values(template.findResources('AWS::IAM::Policy')).flatMap(
+        (p: any) => p.Properties?.PolicyDocument?.Statement ?? [],
+    );
+
+test('grants scoped S3 read access to the asset for the Lambda', () => {
+    const stack = new Stack();
+
+    const secretValues = new SopsSecretsManager(stack, 'SecretValues', {
+        secretName: 'MySecret',
+        path: './test/test.yaml',
+        mappings: {
+            mykey: {
+                path: ['a', 'b'],
+            },
+        },
+    });
+
+    const template = Template.fromStack(stack);
+
+    // S3 read policy must be scoped to specific bucket/key, not a bare '*'
+    const s3Statements = allPolicyStatements(template).filter((s) =>
+        Array.isArray(s.Action) && (s.Action as string[]).some((a) => a.startsWith('s3:')),
+    );
+    expect(s3Statements.length).toBeGreaterThan(0);
+    for (const stmt of s3Statements) {
+        expect(stmt.Resource).not.toBe('*');
+        expect(Array.isArray(stmt.Resource)).toBe(true);
+    }
+
+    void secretValues;
+});
+
+test('grants scoped SecretsManager write access to the specific secret for the Lambda', () => {
+    const stack = new Stack();
+
+    const secretValues = new SopsSecretsManager(stack, 'SecretValues', {
+        secretName: 'MySecret',
+        path: './test/test.yaml',
+        mappings: {
+            mykey: {
+                path: ['a', 'b'],
+            },
+        },
+    });
+
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+            Statement: Match.arrayWith([
+                Match.objectLike({
+                    Action: Match.arrayWith(['secretsmanager:PutSecretValue']),
+                    Resource: stack.resolve((secretValues.secret as secretsManager.Secret).secretArn),
+                }),
+            ]),
+        },
+    });
+
+    const wildcardSM = allPolicyStatements(template).filter((s) => s.Action === 'secretsmanager:*');
+    expect(wildcardSM).toHaveLength(0);
+});
+
+test('grants scoped SecretsManager write access when passing an existing secret', () => {
+    const stack = new Stack();
+
+    const secret = new secretsManager.Secret(stack, 'Secret', {
+        secretName: 'MySecret',
+    });
+
+    new SopsSecretsManager(stack, 'SecretValues', {
+        secret,
+        path: './test/test.yaml',
+        mappings: {
+            mykey: {
+                path: ['a', 'b'],
+            },
+        },
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+            Statement: Match.arrayWith([
+                Match.objectLike({
+                    Action: Match.arrayWith(['secretsmanager:PutSecretValue']),
+                    Resource: stack.resolve(secret.secretArn),
+                }),
+            ]),
+        },
+    });
+});
+
+test('grants scoped KMS decrypt access when a kmsKey is provided', () => {
+    const stack = new Stack();
+
+    const kmsKey = new kms.Key(stack, 'Key');
+
+    new SopsSecretsManager(stack, 'SecretValues', {
+        secretName: 'MySecret',
+        path: './test/test.yaml',
+        kmsKey,
+        mappings: {
+            mykey: {
+                path: ['a', 'b'],
+            },
+        },
+    });
+
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+            Statement: Match.arrayWith([
+                Match.objectLike({
+                    Action: 'kms:Decrypt',
+                    Resource: stack.resolve(kmsKey.keyArn),
+                }),
+            ]),
+        },
+    });
+
+    const wildcardKMS = allPolicyStatements(template).filter((s) => s.Action === 'kms:*');
+    expect(wildcardKMS).toHaveLength(0);
 });
 
 // No node12 hack behaviour to test in cdk v2

--- a/test/cdkv2.test.ts
+++ b/test/cdkv2.test.ts
@@ -213,15 +213,10 @@ test('uses a secret, creates a custom resource', () => {
 });
 
 const allPolicyStatements = (template: Template): Array<Record<string, unknown>> =>
-    Object.values(template.findResources('AWS::IAM::Policy')).flatMap(
-        (p: any) => p.Properties?.PolicyDocument?.Statement ?? [],
-    );
+    Object.values(template.findResources('AWS::IAM::Policy')).flatMap(p => p.Properties?.PolicyDocument?.Statement ?? []);
 
 const hasWildcardAction = (statements: Array<Record<string, unknown>>, action: string): boolean =>
-    statements.some((s) =>
-        s.Action === action ||
-        (Array.isArray(s.Action) && (s.Action as string[]).includes(action)),
-    );
+    statements.some(s => s.Action === action || (Array.isArray(s.Action) && (s.Action as string[]).includes(action)));
 
 test('grants scoped S3 read access to the asset for the Lambda', () => {
     const stack = new Stack();
@@ -239,9 +234,7 @@ test('grants scoped S3 read access to the asset for the Lambda', () => {
     const template = Template.fromStack(stack);
 
     // S3 read policy must be scoped to specific bucket/key, not a bare '*'
-    const s3Statements = allPolicyStatements(template).filter((s) =>
-        Array.isArray(s.Action) && (s.Action as string[]).some((a) => a.startsWith('s3:')),
-    );
+    const s3Statements = allPolicyStatements(template).filter(s => Array.isArray(s.Action) && (s.Action as string[]).some(a => a.startsWith('s3:')));
     expect(s3Statements.length).toBeGreaterThan(0);
     for (const stmt of s3Statements) {
         expect(stmt.Resource).not.toBe('*');
@@ -342,7 +335,7 @@ test('grants scoped KMS decrypt access when a kmsKey is provided', () => {
     expect(hasWildcardAction(allPolicyStatements(template), 'kms:*')).toBe(false);
 
     // When a specific key is provided the resource must also be scoped (no kms:Decrypt *)
-    const wildcardDecrypt = allPolicyStatements(template).filter((s) => {
+    const wildcardDecrypt = allPolicyStatements(template).filter(s => {
         const isDecrypt = s.Action === 'kms:Decrypt' || (Array.isArray(s.Action) && (s.Action as string[]).includes('kms:Decrypt'));
         return isDecrypt && s.Resource === '*';
     });
@@ -365,7 +358,7 @@ test('falls back to kms:Decrypt * when no kmsKey is provided', () => {
     const template = Template.fromStack(stack);
     const stmts = allPolicyStatements(template);
 
-    const wildcardDecrypt = stmts.filter((s) => {
+    const wildcardDecrypt = stmts.filter(s => {
         const isDecrypt = s.Action === 'kms:Decrypt' || (Array.isArray(s.Action) && (s.Action as string[]).includes('kms:Decrypt'));
         return isDecrypt && s.Resource === '*';
     });


### PR DESCRIPTION
IAM permissions for the Lambda were much broader than they needed to be. This scopes them to only what is actually needed.